### PR TITLE
Remove vary replace dalle3

### DIFF
--- a/darth_d/__init__.py
+++ b/darth_d/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 from ._create import create
 from ._vary import vary

--- a/darth_d/_napari_plugin.py
+++ b/darth_d/_napari_plugin.py
@@ -18,26 +18,6 @@ def create_gui_dalle2(prompt:str, image_size:int=256, num_images:int = 1) -> "na
     return image
 
 
-@register_function(menu="Generate > Create new image (DALL-E 3, OpenAI, Darth-D)",
-                   prompt={"widget_type": "TextEdit"},
-                   image_size={"choices": ["1024x1024", "1024x1792", "1792x1024"]},
-                   quality={"choices": ["standard", "hd"]},
-                   style={"choices": ["vivid", "natural"]}
-                   )
-def create_gui_dalle3(prompt:str, image_size:int="1024x1024", quality:str="standard", style:str="vivid") -> "napari.types.ImageData":
-    from ._create import create
-
-    image_size = image_size.split("x")
-    image_width = int(image_size[0])
-    image_height = int(image_size[1])
-
-    image = create(prompt=prompt, image_width=image_width, image_height=image_height, model='dall-e-3')
-
-    return image
-
-
-
-
 @register_function(menu="Generate > Vary image (DALL-E 2, OpenAI, Darth-D)",
                    image_size={"choices": [256, 512, 1024]})
 def vary_gui_dalle2(input_image:"napari.types.ImageData", image_size:int=256, num_images:int = 1) -> "napari.types.ImageData":
@@ -90,25 +70,6 @@ def replace_gui_dalle2(input_image:"napari.types.ImageData", mask:"napari.types.
     
 
 
-@register_function(menu="Generate > Replace masked region (DALL-E 3, OpenAI, Darth-D)",
-                   prompt={"widget_type": "TextEdit"},
-                   image_size={"choices": ["1024x1024", "1024x1792", "1792x1024"]})
-def replace_gui_dalle3(input_image:"napari.types.ImageData", mask:"napari.types.LabelsData", prompt:str = "A similar pattern like in the rest of the image", image_size:str="1024x1024") -> "napari.types.ImageData":
-    from ._replace import replace
-
-    image_size = image_size.split("x")
-    image_width = int(image_size[0])
-    image_height = int(image_size[1])
-
-    image = replace(input_image=input_image, mask=mask, prompt=prompt, image_width=image_width, image_height=image_height, model='dall-e-3')
-
-    try:
-        from napari.utils.notifications import show_warning
-        show_warning("Using the replace function on scientific images could be seen as scientific misconduct. Handle this function with care.")
-    except:
-        pass
-
-    return image
 
 
 @register_function(menu="Generate > Replace entire image (DALL-E 2, OpenAI, Darth-D)",
@@ -127,22 +88,3 @@ def replace_entire_image_gui_dalle2(input_image:"napari.types.ImageData", prompt
     return image
 
 
-@register_function(menu="Generate > Replace entire image (DALL-E 3, OpenAI, Darth-D)",
-                   prompt={"widget_type": "TextEdit"},
-                   image_size={"choices": ["1024x1024", "1024x1792", "1792x1024"]})
-def replace_entire_image_gui_dalle2(input_image:"napari.types.ImageData", prompt:str = "A similar pattern like in the rest of the image", image_size:str="1024x1024") -> "napari.types.ImageData":
-    from ._replace import replace
-
-    image_size = image_size.split("x")
-    image_width = int(image_size[0])
-    image_height = int(image_size[1])
-
-    image = replace(input_image=input_image, mask=None, prompt=prompt, image_width=image_width, image_height=image_height, model='dall-e-3')
-
-    try:
-        from napari.utils.notifications import show_warning
-        show_warning("Using the replace function on scientific images could be seen as scientific misconduct. Handle this function with care.")
-    except:
-        pass
-
-    return image

--- a/darth_d/_replace.py
+++ b/darth_d/_replace.py
@@ -2,9 +2,9 @@ from stackview import jupyter_displayable_output
 from warnings import warn
 
 @jupyter_displayable_output(library_name='darth-d', help_url='https://github.com/haesleinhuepf/darth-d')
-def replace(input_image, mask = None, prompt:str = "A similar pattern like in the rest of the image", image_width:int=1024, image_height:int=1024, num_images:int = 1, model:str="dall-e-3"):
+def replace(input_image, mask = None, prompt:str = "A similar pattern like in the rest of the image", image_width:int=1024, image_height:int=1024, num_images:int = 1):
     """
-    Replace a masked region in an image with a new pattern as described in a prompt using OpenAI's DALL-E 2 or 3.
+    Replace a masked region in an image with a new pattern as described in a prompt using OpenAI's DALL-E 2.
     In case no mask is given, the entire image is replaced in a two-step process:
     First the upper left and lower bottom half of the image is replaced. Afterwards the other two quadrants.
     This may lead to artifacts at quadrant borders.
@@ -15,13 +15,10 @@ def replace(input_image, mask = None, prompt:str = "A similar pattern like in th
     mask: 2D image, optional
     prompt: str, optional
     num_images: int, optional
-        ignored for dall-e-3
-    model: str, optional
-        "dall-e-2", "dall-e-3"
     image_width: int, optional
-        must be 256, 512 or 1024 for dall-e-2 or 1024, 1792 for dall-e-3
+        must be 256, 512 or 1024 for dall-e-2
     image_height: int, optional
-        must be 256, 512 or 1024 for dall-e-2 or 1024, 1792 for dall-e-3
+        must be 256, 512 or 1024 for dall-e-2
 
     See Also
     --------
@@ -38,6 +35,8 @@ def replace(input_image, mask = None, prompt:str = "A similar pattern like in th
     from openai import OpenAI
     from ._utilities import images_from_url_responses
     from warnings import warn
+
+    model: str = "dall-e-2"
 
     warn("Using the replace function on scientific images could be seen as scientific misconduct. Handle this function with care.")
 

--- a/darth_d/_vary.py
+++ b/darth_d/_vary.py
@@ -1,8 +1,8 @@
 from stackview import jupyter_displayable_output
 
 @jupyter_displayable_output(library_name='darth-d', help_url='https://github.com/haesleinhuepf/darth-d')
-def vary(input_image, image_width:int=1024, image_height:int=1024, num_images:int=1, model:str="dall-e-3"):
-    """Varies an image using OpenAI's DALL-E 2 or 3.
+def vary(input_image, image_width:int=1024, image_height:int=1024, num_images:int=1):
+    """Varies an image using OpenAI's DALL-E 2.
 
     Parameters
     ----------
@@ -12,9 +12,9 @@ def vary(input_image, image_width:int=1024, image_height:int=1024, num_images:in
     model: str, optional
         "dall-e-2", "dall-e-3"
     image_width: int, optional
-        must be 256, 512 or 1024 for dall-e-2 or 1024, 1792 for dall-e-3
+        must be 256, 512 or 1024 for dall-e-2
     image_height: int, optional
-        must be 256, 512 or 1024 for dall-e-2 or 1024, 1792 for dall-e-3
+        must be 256, 512 or 1024 for dall-e-2
 
     See Also
     --------
@@ -30,6 +30,8 @@ def vary(input_image, image_width:int=1024, image_height:int=1024, num_images:in
     
     from stackview._image_widget import _img_to_rgb
     from warnings import warn
+
+    model: str = "dall-e-2"
 
     warn("Using the vary function on scientific images could be seen as scientific misconduct. Handle this function with care.")
     client = OpenAI()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # setup.cfg
 [metadata]
 name = darth-d
-version = 0.3.0
+version = 0.4.0
 author = Robert Haase
 author_email = robert.haase@uni-leipzig.de
 description = A simple to use image generator based on OpenAIs DALL-E


### PR DESCRIPTION
This removes support for dall-e-3 in vary and replace functions, because this model is not supported yet by  the OpenAI API